### PR TITLE
Fix compile issue for Teensy 3.2 boards. 

### DIFF
--- a/Firmware/Example1_BasicReadings/MLX90640_I2C_Driver.h
+++ b/Firmware/Example1_BasicReadings/MLX90640_I2C_Driver.h
@@ -31,7 +31,7 @@
 //SAMD21 uses RingBuffer.h
 #define I2C_BUFFER_LENGTH SERIAL_BUFFER_SIZE
 
-#elif __MK20DX256__
+//#elif __MK20DX256__
 //Teensy
 
 #elif ARDUINO_ARCH_ESP32

--- a/Firmware/Example2_OutputToProcessing/MLX90640_I2C_Driver.h
+++ b/Firmware/Example2_OutputToProcessing/MLX90640_I2C_Driver.h
@@ -31,7 +31,7 @@
 //SAMD21 uses RingBuffer.h
 #define I2C_BUFFER_LENGTH SERIAL_BUFFER_SIZE
 
-#elif __MK20DX256__
+//#elif __MK20DX256__
 //Teensy
 
 #elif ARDUINO_ARCH_ESP32


### PR DESCRIPTION
Firmware did not work with Teensy 3.2 because I2C_BUFFER_LENGTH was never defined. Commenting out the elif for Teensy boards fixes this issue, but I am not sure if a buffer length of 32 is correct.