### PR TITLE
Add optional non-adjusting temperatures activated by removing comment…

### DIFF
--- a/Firmware/Example2_OutputToProcessing/MLXHeatCam/MLXHeatCam.pde
+++ b/Firmware/Example2_OutputToProcessing/MLXHeatCam/MLXHeatCam.pde
@@ -103,6 +103,10 @@ void draw() {
     
   }  
   
+  // Uncomment out the following two lines to enable static min and max temperatures
+  // maxTemp = 10;
+  // minTemp = 45;
+
   // for each of the 768 values, map the temperatures between min and max
   // to the blue through red portion of the color space
   for(int q = 0; q < 768; q++){


### PR DESCRIPTION
I thought it was a useful feature as the first thing I did was walk around with the camera and look at stuff. It made it a bit easier to get a feel for the absolute temperature of the objects around me (walking through my house during winter) as opposed to just relative temperature between them. I've never submitted a PR before so if is customary to include more or you need anything else, just let me know.